### PR TITLE
Support for custom fake sequences on non-variadic functions

### DIFF
--- a/fff.h
+++ b/fff.h
@@ -38,6 +38,9 @@ SOFTWARE.
 #define SET_RETURN_SEQ(FUNCNAME, ARRAY_POINTER, ARRAY_LEN) \
                         FUNCNAME##_fake.return_val_seq = ARRAY_POINTER; \
                         FUNCNAME##_fake.return_val_seq_len = ARRAY_LEN;
+#define SET_CUSTOM_FAKE_SEQ(FUNCNAME, ARRAY_POINTER, ARRAY_LEN) \
+                            FUNCNAME##_fake.custom_fake_seq = ARRAY_POINTER; \
+                            FUNCNAME##_fake.custom_fake_seq_len = ARRAY_LEN;
 
 /* Defining a function to reset a fake function */
 #define RESET_FAKE(FUNCNAME) { \
@@ -71,6 +74,10 @@ SOFTWARE.
     int return_val_seq_len; \
     int return_val_seq_idx; \
     RETURN_TYPE * return_val_seq; \
+
+#define DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+    int custom_fake_seq_len; \
+    int custom_fake_seq_idx; \
 
 #define INCREMENT_CALL_COUNT(FUNCNAME) \
     FUNCNAME##_fake.call_count++
@@ -123,7 +130,9 @@ FFF_END_EXTERN_C \
     FFF_EXTERN_C \
         typedef struct FUNCNAME##_Fake { \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(); \
+            void(**custom_fake_seq)(); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -140,6 +149,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -155,7 +172,9 @@ FFF_END_EXTERN_C \
         typedef struct FUNCNAME##_Fake { \
             DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -174,6 +193,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -190,7 +217,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
             DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -211,6 +240,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -228,7 +265,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
             DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -251,6 +290,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -269,7 +316,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
             DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -294,6 +343,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -313,7 +370,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
             DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -340,6 +399,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -360,7 +427,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
             DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -389,6 +458,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -410,7 +487,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
             DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -441,6 +520,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -463,7 +550,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
             DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -496,6 +585,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -519,7 +616,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
             DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -554,6 +653,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -578,7 +685,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
             DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -615,6 +724,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -640,7 +757,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
             DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -679,6 +798,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -705,7 +832,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
             DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -746,6 +875,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -773,7 +910,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
             DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -816,6 +955,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -844,7 +991,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
             DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -889,6 +1038,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -918,7 +1075,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
             DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -965,6 +1124,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -995,7 +1162,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
             DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1044,6 +1213,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -1075,7 +1252,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
             DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1126,6 +1305,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -1158,7 +1345,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
             DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1211,6 +1400,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -1244,7 +1441,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
             DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1299,6 +1498,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -1333,7 +1540,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
             DECLARE_ARG(ARG19_TYPE, 19, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1390,6 +1599,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
+                } \
+                else{ \
+                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \
@@ -1405,7 +1622,9 @@ FFF_END_EXTERN_C \
         typedef struct FUNCNAME##_Fake { \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(); \
+            RETURN_TYPE(**custom_fake_seq)(); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1422,6 +1641,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -1439,7 +1666,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1458,6 +1687,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -1476,7 +1713,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1497,6 +1736,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -1516,7 +1763,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1539,6 +1788,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -1559,7 +1816,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1584,6 +1843,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -1605,7 +1872,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1632,6 +1901,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -1654,7 +1931,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1683,6 +1962,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -1706,7 +1993,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1737,6 +2026,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -1761,7 +2058,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1794,6 +2093,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -1819,7 +2126,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1854,6 +2163,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -1880,7 +2197,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1917,6 +2236,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -1944,7 +2271,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -1983,6 +2312,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -2011,7 +2348,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2052,6 +2391,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -2081,7 +2428,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2124,6 +2473,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -2154,7 +2511,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2199,6 +2558,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -2230,7 +2597,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2277,6 +2646,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -2309,7 +2686,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2358,6 +2737,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -2391,7 +2778,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2442,6 +2831,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -2476,7 +2873,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2529,6 +2928,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -2564,7 +2971,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2619,6 +3028,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -2655,7 +3072,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG19_TYPE, 19, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2712,6 +3131,14 @@ FFF_END_EXTERN_C \
             }\
             INCREMENT_CALL_COUNT(FUNCNAME); \
             REGISTER_CALL(FUNCNAME); \
+            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
+                } \
+                else{ \
+                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
+                } \
+            } \
             if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
@@ -2728,7 +3155,9 @@ FFF_END_EXTERN_C \
         typedef struct FUNCNAME##_Fake { \
             DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2768,7 +3197,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
             DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2811,7 +3242,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
             DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2857,7 +3290,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
             DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2906,7 +3341,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
             DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -2958,7 +3395,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
             DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3013,7 +3452,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
             DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3071,7 +3512,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
             DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3132,7 +3575,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
             DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3196,7 +3641,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
             DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3263,7 +3710,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
             DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3333,7 +3782,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
             DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3406,7 +3857,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
             DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3482,7 +3935,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
             DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3561,7 +4016,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
             DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3643,7 +4100,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
             DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3728,7 +4187,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
             DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3816,7 +4277,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
             DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3907,7 +4370,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
             DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
+            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -3983,7 +4448,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4027,7 +4494,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4074,7 +4543,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4124,7 +4595,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4177,7 +4650,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4233,7 +4708,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4292,7 +4769,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4354,7 +4833,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4419,7 +4900,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4487,7 +4970,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4558,7 +5043,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4632,7 +5119,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4709,7 +5198,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4789,7 +5280,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4872,7 +5365,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -4958,7 +5453,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -5047,7 +5544,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -5139,7 +5638,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \
@@ -5234,7 +5735,9 @@ FFF_END_EXTERN_C \
             DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
             DECLARE_ALL_FUNC_COMMON \
             DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
             RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
+            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
         } FUNCNAME##_Fake;\
         extern FUNCNAME##_Fake FUNCNAME##_fake;\
         void FUNCNAME##_reset(); \

--- a/test/fff_test_c.c
+++ b/test/fff_test_c.c
@@ -24,6 +24,7 @@ struct MyStruct {
 
 FAKE_VOID_FUNC(voidfunc1, int);
 FAKE_VOID_FUNC(voidfunc2, char, char);
+FAKE_VOID_FUNC(voidfunc1outparam, char *);
 FAKE_VALUE_FUNC(long, longfunc0);
 FAKE_VALUE_FUNC(enum MYBOOL, enumfunc0);
 FAKE_VALUE_FUNC(struct MyStruct, structfunc0);
@@ -36,6 +37,7 @@ void setup()
 {
     RESET_FAKE(voidfunc1);
     RESET_FAKE(voidfunc2);
+    RESET_FAKE(voidfunc1outparam);
     RESET_FAKE(longfunc0);
     RESET_FAKE(enumfunc0);
     RESET_FAKE(structfunc0);

--- a/test/fff_test_cpp.cpp
+++ b/test/fff_test_cpp.cpp
@@ -19,6 +19,7 @@ DEFINE_FFF_GLOBALS
 
 FAKE_VOID_FUNC(voidfunc1, int);
 FAKE_VOID_FUNC(voidfunc2, char, char);
+FAKE_VOID_FUNC(voidfunc1outparam, char *);
 FAKE_VALUE_FUNC(long, longfunc0);
 FAKE_VOID_FUNC(voidfunc20, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int);
 
@@ -30,6 +31,7 @@ public:
         RESET_FAKE(voidfunc1);
         RESET_FAKE(voidfunc2);
         RESET_FAKE(longfunc0);
+        RESET_FAKE(voidfunc1outparam);
         FFF_RESET_HISTORY();
     }
 };

--- a/test/fff_test_global_c.c
+++ b/test/fff_test_global_c.c
@@ -10,6 +10,7 @@ void setup()
 {
     RESET_FAKE(voidfunc1);
     RESET_FAKE(voidfunc2);
+    RESET_FAKE(voidfunc1outparam);
     RESET_FAKE(longfunc0);
     RESET_FAKE(enumfunc0);
     RESET_FAKE(structfunc0);

--- a/test/fff_test_global_cpp.cpp
+++ b/test/fff_test_global_cpp.cpp
@@ -14,6 +14,7 @@ public:
         RESET_FAKE(voidfunc1);
         RESET_FAKE(voidfunc2);
         RESET_FAKE(longfunc0);
+        RESET_FAKE(voidfunc1outparam);
         FFF_RESET_HISTORY();
     }
 };

--- a/test/global_fakes.c
+++ b/test/global_fakes.c
@@ -3,6 +3,7 @@
 
 DEFINE_FAKE_VOID_FUNC1(voidfunc1, int);
 DEFINE_FAKE_VOID_FUNC2(voidfunc2, char, char);
+DEFINE_FAKE_VOID_FUNC1(voidfunc1outparam, char *);
 DEFINE_FAKE_VALUE_FUNC0(long, longfunc0);
 DEFINE_FAKE_VALUE_FUNC0(enum MYBOOL, enumfunc0);
 DEFINE_FAKE_VALUE_FUNC0(struct MyStruct, structfunc0);

--- a/test/global_fakes.h
+++ b/test/global_fakes.h
@@ -9,6 +9,7 @@
 ////  Imaginary production code header file ///
 void voidfunc1(int);
 void voidfunc2(char, char);
+void voidfunc1outparam(char *);
 long longfunc0();
 void voidfunc3var(const char *fmt, int argc, ...);
 int valuefunc3var(const char *fmt, int argc, ...);
@@ -25,6 +26,7 @@ struct MyStruct structfunc();
 
 DECLARE_FAKE_VOID_FUNC1(voidfunc1, int);
 DECLARE_FAKE_VOID_FUNC2(voidfunc2, char, char);
+DECLARE_FAKE_VOID_FUNC1(voidfunc1outparam, char *);
 DECLARE_FAKE_VALUE_FUNC0(long, longfunc0);
 DECLARE_FAKE_VALUE_FUNC0(enum MYBOOL, enumfunc0);
 DECLARE_FAKE_VALUE_FUNC0(struct MyStruct, structfunc0);

--- a/test/test_cases.include
+++ b/test/test_cases.include
@@ -225,6 +225,60 @@ TEST_F(FFFTestSuite, can_register_custom_fake)
     ASSERT_EQ(1, my_custom_fake_called);
 }
 
+void voidfunc1outparam_custom_fake1(char *a)
+{
+  *a = 'x';
+}
+
+void voidfunc1outparam_custom_fake2(char *a)
+{
+  *a = 'y';
+}
+
+void voidfunc1outparam_custom_fake3(char *a)
+{
+  *a = 'z';
+}
+
+TEST_F(FFFTestSuite, custom_fake_sequence_not_exausthed)
+{
+  void (*custom_fakes[])(char *) = {voidfunc1outparam_custom_fake1,
+                                    voidfunc1outparam_custom_fake2,
+                                    voidfunc1outparam_custom_fake3};
+  char a = 'a';
+
+  SET_CUSTOM_FAKE_SEQ(voidfunc1outparam, custom_fakes, 3);
+
+  voidfunc1outparam(&a);
+  ASSERT_EQ('x', a);
+  voidfunc1outparam(&a);
+  ASSERT_EQ('y', a);
+  voidfunc1outparam(&a);
+  ASSERT_EQ('z', a);
+}
+
+TEST_F(FFFTestSuite, custom_fake_sequence_exhausted)
+{
+  void (*custom_fakes[])(char *) = {voidfunc1outparam_custom_fake1,
+                                    voidfunc1outparam_custom_fake2,
+                                    voidfunc1outparam_custom_fake3};
+  char a = 'a';
+
+  SET_CUSTOM_FAKE_SEQ(voidfunc1outparam, custom_fakes, 3);
+
+  voidfunc1outparam(&a);
+  ASSERT_EQ('x', a);
+  voidfunc1outparam(&a);
+  ASSERT_EQ('y', a);
+  voidfunc1outparam(&a);
+  ASSERT_EQ('z', a);
+  a = 'a';
+  voidfunc1outparam(&a);
+  ASSERT_EQ('z', a);
+  a = 'b';
+  voidfunc1outparam(&a);
+  ASSERT_EQ('z', a);
+}
 //DECLARE_FAKE_VALUE_FUNC0(long, longfunc0);
 #define MEANING_OF_LIFE 42
 long my_custom_value_fake(void)


### PR DESCRIPTION
We can now set a sequence of custom fakes to be called with the macro
SET_CUSTOM_FAKE_SEQ, which works much like the SET_RETURN_SEQ macro.
At the moment this only works for custom fakes of non-variadic functions.
