### PR TITLE
Fix issue 21: Use function pointer for call_history

### DIFF
--- a/fakegen.rb
+++ b/fakegen.rb
@@ -355,8 +355,9 @@ def output_reset_function(arg_count, is_value_function)
 end
 
 def define_fff_globals
+  putd "typedef void (*fff_function_t)(void);"
   putd "typedef struct { "
-  putd "    void * call_history[FFF_CALL_HISTORY_LEN];"
+  putd "    fff_function_t call_history[FFF_CALL_HISTORY_LEN];"
   putd "    unsigned int call_history_idx;"
   putd "} fff_globals_t;"
   putd ""
@@ -373,7 +374,7 @@ def define_fff_globals
   putd ""
   putd "#define REGISTER_CALL(function) \\"
   putd "   if(fff.call_history_idx < FFF_CALL_HISTORY_LEN) \\"
-  putd "       fff.call_history[fff.call_history_idx++] = (void *)function;"
+  putd "       fff.call_history[fff.call_history_idx++] = (fff_function_t)function;"
 end
 
 def extern_c

--- a/fff.h
+++ b/fff.h
@@ -108,8 +108,9 @@ SOFTWARE.
     }
 /* -- END INTERNAL HELPER MACROS -- */
 
+typedef void (*fff_function_t)(void);
 typedef struct { 
-    void * call_history[FFF_CALL_HISTORY_LEN];
+    fff_function_t call_history[FFF_CALL_HISTORY_LEN];
     unsigned int call_history_idx;
 } fff_globals_t;
 
@@ -126,7 +127,7 @@ FFF_END_EXTERN_C \
 
 #define REGISTER_CALL(function) \
    if(fff.call_history_idx < FFF_CALL_HISTORY_LEN) \
-       fff.call_history[fff.call_history_idx++] = (void *)function;
+       fff.call_history[fff.call_history_idx++] = (fff_function_t)function;
 
 #define DECLARE_FAKE_VOID_FUNC0(FUNCNAME) \
     FFF_EXTERN_C \


### PR DESCRIPTION
This pull request fixes [issue 21](https://github.com/meekrosoft/fff/issues/21). Instead of a void pointer a function pointer is now used for call_history.