### PR TITLE
Adding a section explaining how to fake variadic functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,23 @@ The fake will call your custom functions in the order specified by the SET_CUSTO
 macro. When the last custom fake is reached the fake will keep calling the last custom
 fake in the sequence. This macro works much like the SET_RETURN_SEQ macro.
 
+## Variadic Functions
+
+You can fake variadic functions using the macros <tt>FAKE_VALUE_FUNC_VARARG</tt>
+and <tt>FAKE_VOID_FUNC_VARARG</tt>. For instance:
+
+    FAKE_VALUE_FUNC_VARARG(int, fprintf, FILE *, const char*, ...);
+
+In order to access the variadic parameters from a custom fake function, declare a
+<tt>va_list</tt> parameter. For instance, a custom fake for <tt>fprintf()</tt>
+could call the real <tt>fprintf()</tt> like this:
+
+    int fprintf_custom(FILE *stream, const char *format, va_list ap) {
+      if (fprintf0_fake.return_val < 0) // should we fail?
+        return fprintf0_fake.return_val;
+      return vfprintf(stream, format, ap);
+    }
+
 ## How do I fake a function that returns a value by reference?
 The basic mechanism that FFF provides you in this case is the custom_fake field described in the *Custom Return Value Delegate* example above.
 

--- a/test/test_cases.include
+++ b/test/test_cases.include
@@ -299,6 +299,11 @@ TEST_F(FFFTestSuite, use_void_vararg_fake_with_different_number_of_arguments)
    voidfunc3var("1 parameter",  1, 10);
    voidfunc3var("2 parameters", 2, 10, 20);
    voidfunc3var("3 parameters", 3, 10, 20, 30);
+
+   ASSERT_EQ(voidfunc3var_fake.call_count, 4);
+   char msg[] = "3 parameters";
+   ASSERT_EQ(strcmp(voidfunc3var_fake.arg0_val, msg), 0);
+   ASSERT_EQ(3, voidfunc3var_fake.arg1_val);
 }
 
 TEST_F(FFFTestSuite, use_value_vararg_fake_with_different_number_of_arguments)
@@ -307,6 +312,11 @@ TEST_F(FFFTestSuite, use_value_vararg_fake_with_different_number_of_arguments)
    valuefunc3var("1 parameter",  1, 10);
    valuefunc3var("2 parameters", 2, 10, 20);
    valuefunc3var("3 parameters", 3, 10, 20, 30);
+
+   ASSERT_EQ(valuefunc3var_fake.call_count, 4);
+   char msg[] = "3 parameters";
+   ASSERT_EQ(strcmp(valuefunc3var_fake.arg0_val, msg), 0);
+   ASSERT_EQ(3, valuefunc3var_fake.arg1_val);
 }
 #endif /* __cplusplus */
 


### PR DESCRIPTION
This commit adds a new section to the README explaning how to fake variadic functions and how to access variadic parameters from a custom fake function.