### PR TITLE
a POC for keeping return history of custom_fake's

### DIFF
--- a/fff.h
+++ b/fff.h
@@ -1743,7 +1743,11 @@ FFF_END_EXTERN_C \
                     return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0); \
                 } \
             } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0); \
+			if (FUNCNAME##_fake.custom_fake){ \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0); \
+				SAVE_RET_HISTORY(FUNCNAME, ret); \
+				return ret; \
+			} \
             RETURN_FAKE_RESULT(FUNCNAME)  \
         } \
         DEFINE_RESET_FUNCTION(FUNCNAME) \


### PR DESCRIPTION
Hi all,
I would like to ask you if this change makes sense.

In my test scenario a Function Under Test was calling mock generated by fff, this mock had a custom_fake defined, this custom_fake was doing calloc and returning pointer to allocated area, then my function under test was storing this ptr in struct field.
My idea was to assert that pointers returned by custom_fake and stored in struct field pointing to the same area.
I tried to use func_fake.return_val_history[] but it was empty.
And I've found that history is stored only in case when custom_fake_seq is set.
So I modified returning value from custom_fake and added SAVE_RET_HISTORY.

My test scenario is quite strange, and most probably I will change it. If this change to fff makes sense I can add it to all functions together with tests.

Br,
Mykhailo
