### PR TITLE
Remove extern "C" from fake declarations.

### DIFF
--- a/examples/driver_testing/driver.test.fff.cpp
+++ b/examples/driver_testing/driver.test.fff.cpp
@@ -1,6 +1,7 @@
 extern "C"{
     #include "driver.h"
     #include "registers.h"
+    #include "hardware_abstraction.h"
 }
 #include "../../fff.h"
 #include <gtest/gtest.h>

--- a/fakegen.rb
+++ b/fakegen.rb
@@ -271,23 +271,19 @@ def output_macro(arg_count, has_varargs, is_value_function)
   puts
   output_macro_header(declare_macro_name, saved_arg_count, has_varargs, return_type)
   indent {
-    extern_c {  # define argument capture variables
-      output_variables(saved_arg_count, has_varargs, is_value_function)
-    }
+    output_variables(saved_arg_count, has_varargs, is_value_function)
   }
   
   puts
   output_macro_header(define_macro_name, saved_arg_count, has_varargs, return_type)
   indent {
-    extern_c {
-      putd_backslash "FUNCNAME##_Fake FUNCNAME##_fake;"
-      putd_backslash function_signature(saved_arg_count, has_varargs, is_value_function) + "{"
-      indent {
-        output_function_body(saved_arg_count, has_varargs, is_value_function)
-      }
-      putd_backslash "}"
-      putd_backslash "DEFINE_RESET_FUNCTION(FUNCNAME)"
+    putd_backslash "FUNCNAME##_Fake FUNCNAME##_fake;"
+    putd_backslash function_signature(saved_arg_count, has_varargs, is_value_function) + "{"
+    indent {
+      output_function_body(saved_arg_count, has_varargs, is_value_function)
     }
+    putd_backslash "}"
+    putd_backslash "DEFINE_RESET_FUNCTION(FUNCNAME)"
   }
   
   puts
@@ -453,9 +449,9 @@ def define_fff_globals
   }
   putd "} fff_globals_t;"
   puts
-  putd_backslash "FFF_EXTERN_C"
+  putd "FFF_EXTERN_C"
   putd "extern fff_globals_t fff;"
-  putd_backslash "FFF_END_EXTERN_C"
+  putd "FFF_END_EXTERN_C"
   puts
   putd_backslash "#define DEFINE_FFF_GLOBALS"
   indent {
@@ -475,14 +471,6 @@ def define_fff_globals
 		putd "fff.call_history[fff.call_history_idx++] = (fff_function_t)function;"
     }
   }
-end
-
-def extern_c
-  putd_backslash "FFF_EXTERN_C"
-  indent { 
-    yield
-  }
-  putd_backslash "FFF_END_EXTERN_C"
 end
 
 def in_struct

--- a/fff.h
+++ b/fff.h
@@ -124,9 +124,9 @@ typedef struct {
     unsigned int call_history_idx;
 } fff_globals_t;
 
-FFF_EXTERN_C \
+FFF_EXTERN_C
 extern fff_globals_t fff;
-FFF_END_EXTERN_C \
+FFF_END_EXTERN_C
 
 #define DEFINE_FFF_GLOBALS \
     FFF_EXTERN_C \
@@ -140,5932 +140,5612 @@ FFF_END_EXTERN_C \
         fff.call_history[fff.call_history_idx++] = (fff_function_t)function;
 
 #define DECLARE_FAKE_VOID_FUNC0(FUNCNAME) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(void); \
-            void(**custom_fake_seq)(void); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(void); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(void); \
+        void(**custom_fake_seq)(void); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(void); \
 
 #define DEFINE_FAKE_VOID_FUNC0(FUNCNAME) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(void){ \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(void){ \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC0(FUNCNAME) \
     DECLARE_FAKE_VOID_FUNC0(FUNCNAME) \
     DEFINE_FAKE_VOID_FUNC0(FUNCNAME) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC1(FUNCNAME, ARG0_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0); \
 
 #define DEFINE_FAKE_VOID_FUNC1(FUNCNAME, ARG0_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC1(FUNCNAME, ARG0_TYPE) \
     DECLARE_FAKE_VOID_FUNC1(FUNCNAME, ARG0_TYPE) \
     DEFINE_FAKE_VOID_FUNC1(FUNCNAME, ARG0_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC2(FUNCNAME, ARG0_TYPE, ARG1_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1); \
 
 #define DEFINE_FAKE_VOID_FUNC2(FUNCNAME, ARG0_TYPE, ARG1_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC2(FUNCNAME, ARG0_TYPE, ARG1_TYPE) \
     DECLARE_FAKE_VOID_FUNC2(FUNCNAME, ARG0_TYPE, ARG1_TYPE) \
     DEFINE_FAKE_VOID_FUNC2(FUNCNAME, ARG0_TYPE, ARG1_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC3(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
 
 #define DEFINE_FAKE_VOID_FUNC3(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC3(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE) \
     DECLARE_FAKE_VOID_FUNC3(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE) \
     DEFINE_FAKE_VOID_FUNC3(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC4(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
 
 #define DEFINE_FAKE_VOID_FUNC4(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC4(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
     DECLARE_FAKE_VOID_FUNC4(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
     DEFINE_FAKE_VOID_FUNC4(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC5(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
 
 #define DEFINE_FAKE_VOID_FUNC5(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC5(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE) \
     DECLARE_FAKE_VOID_FUNC5(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE) \
     DEFINE_FAKE_VOID_FUNC5(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC6(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
 
 #define DEFINE_FAKE_VOID_FUNC6(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC6(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE) \
     DECLARE_FAKE_VOID_FUNC6(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE) \
     DEFINE_FAKE_VOID_FUNC6(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC7(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
 
 #define DEFINE_FAKE_VOID_FUNC7(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC7(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE) \
     DECLARE_FAKE_VOID_FUNC7(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE) \
     DEFINE_FAKE_VOID_FUNC7(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC8(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
 
 #define DEFINE_FAKE_VOID_FUNC8(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC8(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE) \
     DECLARE_FAKE_VOID_FUNC8(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE) \
     DEFINE_FAKE_VOID_FUNC8(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC9(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
 
 #define DEFINE_FAKE_VOID_FUNC9(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC9(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
     DECLARE_FAKE_VOID_FUNC9(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
     DEFINE_FAKE_VOID_FUNC9(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC10(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
 
 #define DEFINE_FAKE_VOID_FUNC10(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC10(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE) \
     DECLARE_FAKE_VOID_FUNC10(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE) \
     DEFINE_FAKE_VOID_FUNC10(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC11(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
 
 #define DEFINE_FAKE_VOID_FUNC11(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC11(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE) \
     DECLARE_FAKE_VOID_FUNC11(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE) \
     DEFINE_FAKE_VOID_FUNC11(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC12(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
 
 #define DEFINE_FAKE_VOID_FUNC12(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC12(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE) \
     DECLARE_FAKE_VOID_FUNC12(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE) \
     DEFINE_FAKE_VOID_FUNC12(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC13(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
 
 #define DEFINE_FAKE_VOID_FUNC13(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC13(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE) \
     DECLARE_FAKE_VOID_FUNC13(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE) \
     DEFINE_FAKE_VOID_FUNC13(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC14(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
 
 #define DEFINE_FAKE_VOID_FUNC14(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC14(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE) \
     DECLARE_FAKE_VOID_FUNC14(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE) \
     DEFINE_FAKE_VOID_FUNC14(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC15(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
 
 #define DEFINE_FAKE_VOID_FUNC15(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC15(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE) \
     DECLARE_FAKE_VOID_FUNC15(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE) \
     DEFINE_FAKE_VOID_FUNC15(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC16(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
 
 #define DEFINE_FAKE_VOID_FUNC16(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC16(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE) \
     DECLARE_FAKE_VOID_FUNC16(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE) \
     DEFINE_FAKE_VOID_FUNC16(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC17(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
 
 #define DEFINE_FAKE_VOID_FUNC17(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC17(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE) \
     DECLARE_FAKE_VOID_FUNC17(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE) \
     DEFINE_FAKE_VOID_FUNC17(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC18(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
 
 #define DEFINE_FAKE_VOID_FUNC18(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            SAVE_ARG(FUNCNAME, 17); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-                SAVE_ARG_HISTORY(FUNCNAME, 17); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        SAVE_ARG(FUNCNAME, 17); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+            SAVE_ARG_HISTORY(FUNCNAME, 17); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC18(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE) \
     DECLARE_FAKE_VOID_FUNC18(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE) \
     DEFINE_FAKE_VOID_FUNC18(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC19(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
-            DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
+        DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
 
 #define DEFINE_FAKE_VOID_FUNC19(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            SAVE_ARG(FUNCNAME, 17); \
-            SAVE_ARG(FUNCNAME, 18); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-                SAVE_ARG_HISTORY(FUNCNAME, 17); \
-                SAVE_ARG_HISTORY(FUNCNAME, 18); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        SAVE_ARG(FUNCNAME, 17); \
+        SAVE_ARG(FUNCNAME, 18); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+            SAVE_ARG_HISTORY(FUNCNAME, 17); \
+            SAVE_ARG_HISTORY(FUNCNAME, 18); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC19(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE) \
     DECLARE_FAKE_VOID_FUNC19(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE) \
     DEFINE_FAKE_VOID_FUNC19(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC20(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
-            DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
-            DECLARE_ARG(ARG19_TYPE, 19, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
+        DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
+        DECLARE_ARG(ARG19_TYPE, 19, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
 
 #define DEFINE_FAKE_VOID_FUNC20(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            SAVE_ARG(FUNCNAME, 17); \
-            SAVE_ARG(FUNCNAME, 18); \
-            SAVE_ARG(FUNCNAME, 19); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-                SAVE_ARG_HISTORY(FUNCNAME, 17); \
-                SAVE_ARG_HISTORY(FUNCNAME, 18); \
-                SAVE_ARG_HISTORY(FUNCNAME, 19); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        SAVE_ARG(FUNCNAME, 17); \
+        SAVE_ARG(FUNCNAME, 18); \
+        SAVE_ARG(FUNCNAME, 19); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+            SAVE_ARG_HISTORY(FUNCNAME, 17); \
+            SAVE_ARG_HISTORY(FUNCNAME, 18); \
+            SAVE_ARG_HISTORY(FUNCNAME, 19); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
-                } \
-                else{ \
-                    FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC20(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE) \
     DECLARE_FAKE_VOID_FUNC20(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE) \
     DEFINE_FAKE_VOID_FUNC20(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC0(RETURN_TYPE, FUNCNAME) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(void); \
-            RETURN_TYPE(**custom_fake_seq)(void); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(void); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(void); \
+        RETURN_TYPE(**custom_fake_seq)(void); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(void); \
 
 #define DEFINE_FAKE_VALUE_FUNC0(RETURN_TYPE, FUNCNAME) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(void){ \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(void){ \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC0(RETURN_TYPE, FUNCNAME) \
     DECLARE_FAKE_VALUE_FUNC0(RETURN_TYPE, FUNCNAME) \
     DEFINE_FAKE_VALUE_FUNC0(RETURN_TYPE, FUNCNAME) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC1(RETURN_TYPE, FUNCNAME, ARG0_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0); \
 
 #define DEFINE_FAKE_VALUE_FUNC1(RETURN_TYPE, FUNCNAME, ARG0_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC1(RETURN_TYPE, FUNCNAME, ARG0_TYPE) \
     DECLARE_FAKE_VALUE_FUNC1(RETURN_TYPE, FUNCNAME, ARG0_TYPE) \
     DEFINE_FAKE_VALUE_FUNC1(RETURN_TYPE, FUNCNAME, ARG0_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC2(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1); \
 
 #define DEFINE_FAKE_VALUE_FUNC2(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC2(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE) \
     DECLARE_FAKE_VALUE_FUNC2(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE) \
     DEFINE_FAKE_VALUE_FUNC2(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC3(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2); \
 
 #define DEFINE_FAKE_VALUE_FUNC3(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC3(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE) \
     DECLARE_FAKE_VALUE_FUNC3(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE) \
     DEFINE_FAKE_VALUE_FUNC3(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC4(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3); \
 
 #define DEFINE_FAKE_VALUE_FUNC4(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC4(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
     DECLARE_FAKE_VALUE_FUNC4(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
     DEFINE_FAKE_VALUE_FUNC4(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC5(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4); \
 
 #define DEFINE_FAKE_VALUE_FUNC5(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC5(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE) \
     DECLARE_FAKE_VALUE_FUNC5(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE) \
     DEFINE_FAKE_VALUE_FUNC5(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC6(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5); \
 
 #define DEFINE_FAKE_VALUE_FUNC6(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC6(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE) \
     DECLARE_FAKE_VALUE_FUNC6(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE) \
     DEFINE_FAKE_VALUE_FUNC6(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC7(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6); \
 
 #define DEFINE_FAKE_VALUE_FUNC7(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC7(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE) \
     DECLARE_FAKE_VALUE_FUNC7(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE) \
     DEFINE_FAKE_VALUE_FUNC7(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC8(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7); \
 
 #define DEFINE_FAKE_VALUE_FUNC8(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC8(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE) \
     DECLARE_FAKE_VALUE_FUNC8(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE) \
     DEFINE_FAKE_VALUE_FUNC8(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC9(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8); \
 
 #define DEFINE_FAKE_VALUE_FUNC9(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC9(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
     DECLARE_FAKE_VALUE_FUNC9(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
     DEFINE_FAKE_VALUE_FUNC9(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC10(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9); \
 
 #define DEFINE_FAKE_VALUE_FUNC10(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC10(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE) \
     DECLARE_FAKE_VALUE_FUNC10(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE) \
     DEFINE_FAKE_VALUE_FUNC10(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC11(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10); \
 
 #define DEFINE_FAKE_VALUE_FUNC11(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC11(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE) \
     DECLARE_FAKE_VALUE_FUNC11(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE) \
     DEFINE_FAKE_VALUE_FUNC11(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC12(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11); \
 
 #define DEFINE_FAKE_VALUE_FUNC12(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC12(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE) \
     DECLARE_FAKE_VALUE_FUNC12(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE) \
     DEFINE_FAKE_VALUE_FUNC12(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC13(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12); \
 
 #define DEFINE_FAKE_VALUE_FUNC13(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC13(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE) \
     DECLARE_FAKE_VALUE_FUNC13(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE) \
     DEFINE_FAKE_VALUE_FUNC13(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC14(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13); \
 
 #define DEFINE_FAKE_VALUE_FUNC14(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC14(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE) \
     DECLARE_FAKE_VALUE_FUNC14(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE) \
     DEFINE_FAKE_VALUE_FUNC14(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC15(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14); \
 
 #define DEFINE_FAKE_VALUE_FUNC15(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC15(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE) \
     DECLARE_FAKE_VALUE_FUNC15(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE) \
     DEFINE_FAKE_VALUE_FUNC15(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC16(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15); \
 
 #define DEFINE_FAKE_VALUE_FUNC16(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC16(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE) \
     DECLARE_FAKE_VALUE_FUNC16(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE) \
     DEFINE_FAKE_VALUE_FUNC16(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC17(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16); \
 
 #define DEFINE_FAKE_VALUE_FUNC17(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC17(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE) \
     DECLARE_FAKE_VALUE_FUNC17(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE) \
     DEFINE_FAKE_VALUE_FUNC17(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC18(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17); \
 
 #define DEFINE_FAKE_VALUE_FUNC18(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            SAVE_ARG(FUNCNAME, 17); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-                SAVE_ARG_HISTORY(FUNCNAME, 17); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        SAVE_ARG(FUNCNAME, 17); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+            SAVE_ARG_HISTORY(FUNCNAME, 17); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC18(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE) \
     DECLARE_FAKE_VALUE_FUNC18(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE) \
     DEFINE_FAKE_VALUE_FUNC18(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC19(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
-            DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
+        DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18); \
 
 #define DEFINE_FAKE_VALUE_FUNC19(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            SAVE_ARG(FUNCNAME, 17); \
-            SAVE_ARG(FUNCNAME, 18); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-                SAVE_ARG_HISTORY(FUNCNAME, 17); \
-                SAVE_ARG_HISTORY(FUNCNAME, 18); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        SAVE_ARG(FUNCNAME, 17); \
+        SAVE_ARG(FUNCNAME, 18); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+            SAVE_ARG_HISTORY(FUNCNAME, 17); \
+            SAVE_ARG_HISTORY(FUNCNAME, 18); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC19(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE) \
     DECLARE_FAKE_VALUE_FUNC19(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE) \
     DEFINE_FAKE_VALUE_FUNC19(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC20(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
-            DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
-            DECLARE_ARG(ARG19_TYPE, 19, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
+        DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
+        DECLARE_ARG(ARG19_TYPE, 19, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19); \
 
 #define DEFINE_FAKE_VALUE_FUNC20(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            SAVE_ARG(FUNCNAME, 17); \
-            SAVE_ARG(FUNCNAME, 18); \
-            SAVE_ARG(FUNCNAME, 19); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-                SAVE_ARG_HISTORY(FUNCNAME, 17); \
-                SAVE_ARG_HISTORY(FUNCNAME, 18); \
-                SAVE_ARG_HISTORY(FUNCNAME, 19); \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ARG19_TYPE arg19){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        SAVE_ARG(FUNCNAME, 17); \
+        SAVE_ARG(FUNCNAME, 18); \
+        SAVE_ARG(FUNCNAME, 19); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+            SAVE_ARG_HISTORY(FUNCNAME, 17); \
+            SAVE_ARG_HISTORY(FUNCNAME, 18); \
+            SAVE_ARG_HISTORY(FUNCNAME, 19); \
+        } \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
+            if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
             } \
             else{ \
-                HISTORY_DROPPED(FUNCNAME); \
+                RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
+                SAVE_RET_HISTORY(FUNCNAME, ret); \
+                return ret; \
+                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
             } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if (FUNCNAME##_fake.custom_fake_seq_len){ /* a sequence of custom fakes */ \
-                if (FUNCNAME##_fake.custom_fake_seq_idx < FUNCNAME##_fake.custom_fake_seq_len){ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                } \
-                else{ \
-                    RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
-                    SAVE_RET_HISTORY(FUNCNAME, ret); \
-                    return ret; \
-                    return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
-                } \
-            } \
-            if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
-            RETURN_FAKE_RESULT(FUNCNAME) \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        if (FUNCNAME##_fake.custom_fake) return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC20(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE) \
     DECLARE_FAKE_VALUE_FUNC20(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE) \
     DEFINE_FAKE_VALUE_FUNC20(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC2_VARARG(FUNCNAME, ARG0_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC2_VARARG(FUNCNAME, ARG0_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg0); \
-                FUNCNAME##_fake.custom_fake(arg0, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg0); \
+            FUNCNAME##_fake.custom_fake(arg0, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC2_VARARG(FUNCNAME, ARG0_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC2_VARARG(FUNCNAME, ARG0_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC2_VARARG(FUNCNAME, ARG0_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC3_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC3_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg1); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg1); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC3_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC3_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC3_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC4_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC4_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg2); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg2); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC4_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC4_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC4_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC5_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC5_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg3); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg3); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC5_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC5_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC5_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC6_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC6_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg4); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg4); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC6_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC6_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC6_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC7_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC7_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg5); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg5); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC7_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC7_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC7_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC8_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC8_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg6); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg6); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC8_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC8_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC8_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC9_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC9_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg7); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg7); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC9_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC9_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC9_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC10_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC10_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg8); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg8); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC10_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC10_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC10_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC11_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC11_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg9); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg9); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC11_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC11_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC11_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC12_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC12_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg10); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg10); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC12_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC12_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC12_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC13_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC13_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg11); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg11); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC13_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC13_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC13_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC14_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC14_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg12); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg12); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC14_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC14_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC14_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC15_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC15_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg13); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg13); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC15_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC15_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC15_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC16_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC16_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg14); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg14); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC16_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC16_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC16_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC17_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC17_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg15); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg15); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC17_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC17_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC17_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC18_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC18_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg16); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg16); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC18_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC18_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC18_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC19_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC19_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            SAVE_ARG(FUNCNAME, 17); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-                SAVE_ARG_HISTORY(FUNCNAME, 17); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg17); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        SAVE_ARG(FUNCNAME, 17); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+            SAVE_ARG_HISTORY(FUNCNAME, 17); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg17); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC19_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC19_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC19_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VOID_FUNC20_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
-            DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
-            void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
+        DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        void(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
+        void(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ...); \
 
 #define DEFINE_FAKE_VOID_FUNC20_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            SAVE_ARG(FUNCNAME, 17); \
-            SAVE_ARG(FUNCNAME, 18); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-                SAVE_ARG_HISTORY(FUNCNAME, 17); \
-                SAVE_ARG_HISTORY(FUNCNAME, 18); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                va_list ap; \
-                va_start(ap, arg18); \
-                FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, ap); \
-                va_end(ap); \
-            } \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        SAVE_ARG(FUNCNAME, 17); \
+        SAVE_ARG(FUNCNAME, 18); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+            SAVE_ARG_HISTORY(FUNCNAME, 17); \
+            SAVE_ARG_HISTORY(FUNCNAME, 18); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            va_list ap; \
+            va_start(ap, arg18); \
+            FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, ap); \
+            va_end(ap); \
+        } \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VOID_FUNC20_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...) \
     DECLARE_FAKE_VOID_FUNC20_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...) \
     DEFINE_FAKE_VOID_FUNC20_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC2_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC2_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg0); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg0); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC2_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC2_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC2_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC3_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC3_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg1); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg1); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC3_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC3_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC3_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC4_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC4_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg2); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg2); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC4_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC4_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC4_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC5_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC5_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg3); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg3); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC5_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC5_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC5_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC6_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC6_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg4); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg4); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC6_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC6_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC6_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC7_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC7_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg5); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg5); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC7_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC7_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC7_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC8_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC8_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg6); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg6); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC8_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC8_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC8_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC9_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC9_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg7); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg7); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC9_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC9_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC9_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC10_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC10_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg8); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg8); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC10_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC10_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC10_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC11_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC11_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg9); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg9); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC11_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC11_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC11_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC12_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC12_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg10); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg10); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC12_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC12_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC12_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC13_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC13_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg11); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg11); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC13_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC13_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC13_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC14_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC14_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg12); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg12); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC14_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC14_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC14_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC15_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC15_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg13); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg13); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC15_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC15_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC15_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC16_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC16_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg14); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg14); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC16_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC16_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC16_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC17_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC17_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg15); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg15); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC17_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC17_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC17_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC18_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC18_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg16); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg16); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC18_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC18_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC18_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC19_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC19_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            SAVE_ARG(FUNCNAME, 17); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-                SAVE_ARG_HISTORY(FUNCNAME, 17); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg17); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        SAVE_ARG(FUNCNAME, 17); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+            SAVE_ARG_HISTORY(FUNCNAME, 17); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg17); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC19_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC19_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC19_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...) \
-    
+
 
 #define DECLARE_FAKE_VALUE_FUNC20_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...) \
-    FFF_EXTERN_C \
-        typedef struct FUNCNAME##_Fake { \
-            DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
-            DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
-            DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
-            DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
-            DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
-            DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
-            DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
-            DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
-            DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
-            DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
-            DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
-            DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
-            DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
-            DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
-            DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
-            DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
-            DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
-            DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
-            DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
-            DECLARE_ALL_FUNC_COMMON \
-            DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
-            DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
-            DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
-            RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
-            RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
-        } FUNCNAME##_Fake; \
-        extern FUNCNAME##_Fake FUNCNAME##_fake; \
-        void FUNCNAME##_reset(void); \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ...); \
-    FFF_END_EXTERN_C \
+    typedef struct FUNCNAME##_Fake { \
+        DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME) \
+        DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME) \
+        DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME) \
+        DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME) \
+        DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME) \
+        DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME) \
+        DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME) \
+        DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME) \
+        DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME) \
+        DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME) \
+        DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME) \
+        DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME) \
+        DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME) \
+        DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME) \
+        DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME) \
+        DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME) \
+        DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME) \
+        DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME) \
+        DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME) \
+        DECLARE_ALL_FUNC_COMMON \
+        DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE) \
+        DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE) \
+        DECLARE_CUSTOM_FAKE_SEQ_VARIABLES \
+        RETURN_TYPE(*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
+        RETURN_TYPE(**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, va_list ap); \
+    } FUNCNAME##_Fake; \
+    extern FUNCNAME##_Fake FUNCNAME##_fake; \
+    void FUNCNAME##_reset(void); \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ...); \
 
 #define DEFINE_FAKE_VALUE_FUNC20_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...) \
-    FFF_EXTERN_C \
-        FUNCNAME##_Fake FUNCNAME##_fake; \
-        RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ...){ \
-            SAVE_ARG(FUNCNAME, 0); \
-            SAVE_ARG(FUNCNAME, 1); \
-            SAVE_ARG(FUNCNAME, 2); \
-            SAVE_ARG(FUNCNAME, 3); \
-            SAVE_ARG(FUNCNAME, 4); \
-            SAVE_ARG(FUNCNAME, 5); \
-            SAVE_ARG(FUNCNAME, 6); \
-            SAVE_ARG(FUNCNAME, 7); \
-            SAVE_ARG(FUNCNAME, 8); \
-            SAVE_ARG(FUNCNAME, 9); \
-            SAVE_ARG(FUNCNAME, 10); \
-            SAVE_ARG(FUNCNAME, 11); \
-            SAVE_ARG(FUNCNAME, 12); \
-            SAVE_ARG(FUNCNAME, 13); \
-            SAVE_ARG(FUNCNAME, 14); \
-            SAVE_ARG(FUNCNAME, 15); \
-            SAVE_ARG(FUNCNAME, 16); \
-            SAVE_ARG(FUNCNAME, 17); \
-            SAVE_ARG(FUNCNAME, 18); \
-            if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
-                SAVE_ARG_HISTORY(FUNCNAME, 0); \
-                SAVE_ARG_HISTORY(FUNCNAME, 1); \
-                SAVE_ARG_HISTORY(FUNCNAME, 2); \
-                SAVE_ARG_HISTORY(FUNCNAME, 3); \
-                SAVE_ARG_HISTORY(FUNCNAME, 4); \
-                SAVE_ARG_HISTORY(FUNCNAME, 5); \
-                SAVE_ARG_HISTORY(FUNCNAME, 6); \
-                SAVE_ARG_HISTORY(FUNCNAME, 7); \
-                SAVE_ARG_HISTORY(FUNCNAME, 8); \
-                SAVE_ARG_HISTORY(FUNCNAME, 9); \
-                SAVE_ARG_HISTORY(FUNCNAME, 10); \
-                SAVE_ARG_HISTORY(FUNCNAME, 11); \
-                SAVE_ARG_HISTORY(FUNCNAME, 12); \
-                SAVE_ARG_HISTORY(FUNCNAME, 13); \
-                SAVE_ARG_HISTORY(FUNCNAME, 14); \
-                SAVE_ARG_HISTORY(FUNCNAME, 15); \
-                SAVE_ARG_HISTORY(FUNCNAME, 16); \
-                SAVE_ARG_HISTORY(FUNCNAME, 17); \
-                SAVE_ARG_HISTORY(FUNCNAME, 18); \
-            } \
-            else{ \
-                HISTORY_DROPPED(FUNCNAME); \
-            } \
-            INCREMENT_CALL_COUNT(FUNCNAME); \
-            REGISTER_CALL(FUNCNAME); \
-            if(FUNCNAME##_fake.custom_fake){ \
-                RETURN_TYPE ret; \
-                va_list ap; \
-                va_start(ap, arg18); \
-                ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, ap); \
-                va_end(ap); \
-                SAVE_RET_HISTORY(FUNCNAME, ret); \
-                return ret; \
-            } \
-            RETURN_FAKE_RESULT(FUNCNAME) \
+    FUNCNAME##_Fake FUNCNAME##_fake; \
+    RETURN_TYPE FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ARG18_TYPE arg18, ...){ \
+        SAVE_ARG(FUNCNAME, 0); \
+        SAVE_ARG(FUNCNAME, 1); \
+        SAVE_ARG(FUNCNAME, 2); \
+        SAVE_ARG(FUNCNAME, 3); \
+        SAVE_ARG(FUNCNAME, 4); \
+        SAVE_ARG(FUNCNAME, 5); \
+        SAVE_ARG(FUNCNAME, 6); \
+        SAVE_ARG(FUNCNAME, 7); \
+        SAVE_ARG(FUNCNAME, 8); \
+        SAVE_ARG(FUNCNAME, 9); \
+        SAVE_ARG(FUNCNAME, 10); \
+        SAVE_ARG(FUNCNAME, 11); \
+        SAVE_ARG(FUNCNAME, 12); \
+        SAVE_ARG(FUNCNAME, 13); \
+        SAVE_ARG(FUNCNAME, 14); \
+        SAVE_ARG(FUNCNAME, 15); \
+        SAVE_ARG(FUNCNAME, 16); \
+        SAVE_ARG(FUNCNAME, 17); \
+        SAVE_ARG(FUNCNAME, 18); \
+        if(ROOM_FOR_MORE_HISTORY(FUNCNAME)){ \
+            SAVE_ARG_HISTORY(FUNCNAME, 0); \
+            SAVE_ARG_HISTORY(FUNCNAME, 1); \
+            SAVE_ARG_HISTORY(FUNCNAME, 2); \
+            SAVE_ARG_HISTORY(FUNCNAME, 3); \
+            SAVE_ARG_HISTORY(FUNCNAME, 4); \
+            SAVE_ARG_HISTORY(FUNCNAME, 5); \
+            SAVE_ARG_HISTORY(FUNCNAME, 6); \
+            SAVE_ARG_HISTORY(FUNCNAME, 7); \
+            SAVE_ARG_HISTORY(FUNCNAME, 8); \
+            SAVE_ARG_HISTORY(FUNCNAME, 9); \
+            SAVE_ARG_HISTORY(FUNCNAME, 10); \
+            SAVE_ARG_HISTORY(FUNCNAME, 11); \
+            SAVE_ARG_HISTORY(FUNCNAME, 12); \
+            SAVE_ARG_HISTORY(FUNCNAME, 13); \
+            SAVE_ARG_HISTORY(FUNCNAME, 14); \
+            SAVE_ARG_HISTORY(FUNCNAME, 15); \
+            SAVE_ARG_HISTORY(FUNCNAME, 16); \
+            SAVE_ARG_HISTORY(FUNCNAME, 17); \
+            SAVE_ARG_HISTORY(FUNCNAME, 18); \
         } \
-        DEFINE_RESET_FUNCTION(FUNCNAME) \
-    FFF_END_EXTERN_C \
+        else{ \
+            HISTORY_DROPPED(FUNCNAME); \
+        } \
+        INCREMENT_CALL_COUNT(FUNCNAME); \
+        REGISTER_CALL(FUNCNAME); \
+        if(FUNCNAME##_fake.custom_fake){ \
+            RETURN_TYPE ret; \
+            va_list ap; \
+            va_start(ap, arg18); \
+            ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, ap); \
+            va_end(ap); \
+            SAVE_RET_HISTORY(FUNCNAME, ret); \
+            return ret; \
+        } \
+        RETURN_FAKE_RESULT(FUNCNAME) \
+    } \
+    DEFINE_RESET_FUNCTION(FUNCNAME) \
 
 #define FAKE_VALUE_FUNC20_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...) \
     DECLARE_FAKE_VALUE_FUNC20_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...) \
     DEFINE_FAKE_VALUE_FUNC20_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...) \
-    
+
 /* MSVC expand macro fix */
 #define EXPAND(x) x
 

--- a/test/fff_test_cpp.cpp
+++ b/test/fff_test_cpp.cpp
@@ -46,3 +46,37 @@ TEST_F(FFFTestSuite, default_constants_can_be_overridden)
     ASSERT_EQ(OVERRIDE_ARG_HIST_LEN, voidfunc2_fake.arg_history_len);
 }
 
+// Fake declared in C++ context (not extern "C", using namespace)
+// before the fake is declared
+namespace cxx
+{
+    typedef int int_t;
+    void voidfunc1(cxx::int_t);
+}
+
+// Now declare the fake.  Must be in the same namespace as the
+// original declaration.
+namespace cxx
+{
+    FAKE_VOID_FUNC(voidfunc1, cxx::int_t);
+}
+
+TEST_F(FFFTestSuite, cxx_fake_is_called)
+{
+    cxx::voidfunc1(66);
+    ASSERT_EQ(cxx::voidfunc1_fake.call_count, 1u);
+    ASSERT_EQ(cxx::voidfunc1_fake.arg0_val, 66);
+}
+
+static int cxx_my_custom_fake_called = 0;
+void cxx_my_custom_fake(cxx::int_t i)
+{
+    cxx_my_custom_fake_called++;
+}
+
+TEST_F(FFFTestSuite, cxx_can_register_custom_fake)
+{
+    cxx::voidfunc1_fake.custom_fake = cxx_my_custom_fake;
+    cxx::voidfunc1(66);
+    ASSERT_EQ(1, cxx_my_custom_fake_called);
+}


### PR DESCRIPTION
Assuming your C interfaces are appropriately wrapped for C++, it is unnecessary to force the fakes to be declared `extern "C"`, and doing so causes any functions declared with C++ linkage to be impossible to fake due to the conflicting linkage declarations.

This also adds a test case that proves a function with C++ linkage can be faked correctly, and fixes one test case that required some declarations to be seen with `extern "C"` before providing the fake implementation.