### PR TITLE
Clear `fff.call_history` when calling `FFF_RESET_HISTORY`

### DIFF
--- a/fakegen.rb
+++ b/fakegen.rb
@@ -466,7 +466,11 @@ def define_fff_globals
     putd "FFF_END_EXTERN_C"
   }
   puts
-  putd "#define FFF_RESET_HISTORY() fff.call_history_idx = 0;"
+  putd_backslash "#define FFF_RESET_HISTORY()"
+  indent {
+    putd_backslash "fff.call_history_idx = 0;"
+    putd "memset(fff.call_history, 0, sizeof(fff.call_history));"
+  }
   puts
   putd_backslash "#define REGISTER_CALL(function)"
   indent {

--- a/fff.h
+++ b/fff.h
@@ -133,7 +133,9 @@ FFF_END_EXTERN_C \
         fff_globals_t fff; \
     FFF_END_EXTERN_C
 
-#define FFF_RESET_HISTORY() fff.call_history_idx = 0;
+#define FFF_RESET_HISTORY() \
+    fff.call_history_idx = 0; \
+    memset(fff.call_history, 0, sizeof(fff.call_history));
 
 #define REGISTER_CALL(function) \
     if(fff.call_history_idx < FFF_CALL_HISTORY_LEN) \

--- a/test/test_cases.include
+++ b/test/test_cases.include
@@ -158,11 +158,13 @@ TEST_F(FFFTestSuite, register_call_macro_registers_two_calls)
 TEST_F(FFFTestSuite, reset_call_history_resets_call_history)
 {
     REGISTER_CALL(longfunc0);
+    REGISTER_CALL(voidfunc1);
     FFF_RESET_HISTORY();
     REGISTER_CALL(voidfunc2);
 
     ASSERT_EQ(1u, fff.call_history_idx);
     ASSERT_EQ(fff.call_history[0], (void *)voidfunc2);
+    ASSERT_EQ(fff.call_history[1], (void *)0);
 }
 
 TEST_F(FFFTestSuite, call_history_will_not_write_past_array_bounds)


### PR DESCRIPTION
`FFF_RESET_HISTORY` now clears out the call history, resolving #50. Hopefully this was the right way to go about it!