### PR TITLE
Implement FFF_RESET_CALLED_FAKES macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,3 +645,4 @@ So whats the point?
 | FAKE_VOID_FUNC_VARARG(fn [,arg_types*], ...); | Define a fake variadic function returning void with type return_type taking n arguments and n variadic arguments | FAKE_VOID_FUNC_VARARG(fn, const char*, ...) |
 | FAKE_VALUE_FUNC_VARARG(return_type, fn [,arg_types*], ...); | Define a fake variadic function returning a value with type return_type taking n arguments and n variadic arguments | FAKE_VALUE_FUNC_VARARG(int, fprintf, FILE*, const char*, ...) |
 | RESET_FAKE(fn); | Reset the state of fake function called fn | RESET_FAKE(DISPLAY_init); |
+| FFF_RESET_CALLED_FAKES(); | Reset the state of all called fake functions globally | FFF_RESET_CALLED_FAKES(); |

--- a/test/fff_test_c.c
+++ b/test/fff_test_c.c
@@ -49,15 +49,7 @@ FAKE_VALUE_FUNC(int, __cdecl, valuefunc20, int, int, int, int, int, int, int, in
 
 void setup()
 {
-    RESET_FAKE(voidfunc1);
-    RESET_FAKE(voidfunc2);
-    RESET_FAKE(voidfunc1outparam);
-    RESET_FAKE(longfunc0);
-    RESET_FAKE(enumfunc0);
-    RESET_FAKE(structfunc0);
-    RESET_FAKE(voidfunc3var);
-    RESET_FAKE(valuefunc3var);
-    RESET_FAKE(strlcpy3);
+    FFF_RESET_CALLED_FAKES();
     FFF_RESET_HISTORY();
 }
 

--- a/test/fff_test_cpp.cpp
+++ b/test/fff_test_cpp.cpp
@@ -42,13 +42,13 @@ class FFFTestSuite: public testing::Test
 public:
     void SetUp()
     {
-        RESET_FAKE(voidfunc1);
-        RESET_FAKE(voidfunc2);
-        RESET_FAKE(longfunc0);
-        RESET_FAKE(voidfunc1outparam);
-        RESET_FAKE(voidfunc3var);
-        RESET_FAKE(valuefunc3var);
+        FFF_RESET_CALLED_FAKES();
         FFF_RESET_HISTORY();
+        RESET_FAKE(voidfunc2); /* Explicitly reset voidfunc2 so arg_history_len
+                                * is set. voidfunc2 is never actually called so
+                                * FFF_RESET_CALLED_FAKES() does not reset it.
+                                * Not doing so would trip assertion in test:
+                                * default_constants_can_be_overridden */
     }
 };
 

--- a/test/fff_test_global_c.c
+++ b/test/fff_test_global_c.c
@@ -8,16 +8,7 @@ DEFINE_FFF_GLOBALS;
 
 void setup()
 {
-    RESET_FAKE(voidfunc1);
-    RESET_FAKE(voidfunc2);
-    RESET_FAKE(voidfunc1outparam);
-    RESET_FAKE(longfunc0);
-    RESET_FAKE(enumfunc0);
-    RESET_FAKE(structfunc0);
-    RESET_FAKE(voidfunc3var);
-    RESET_FAKE(valuefunc3var);
-    RESET_FAKE(strlcpy3);
-
+    FFF_RESET_CALLED_FAKES();
     FFF_RESET_HISTORY();
 }
 

--- a/test/fff_test_global_cpp.cpp
+++ b/test/fff_test_global_cpp.cpp
@@ -11,12 +11,7 @@ class FFFTestSuite: public testing::Test
 public:
     void SetUp()
     {
-        RESET_FAKE(voidfunc1);
-        RESET_FAKE(voidfunc2);
-        RESET_FAKE(longfunc0);
-        RESET_FAKE(voidfunc1outparam);
-        RESET_FAKE(voidfunc3var);
-        RESET_FAKE(valuefunc3var);
+        FFF_RESET_CALLED_FAKES();
         FFF_RESET_HISTORY();
     }
 };


### PR DESCRIPTION
> Thank you for your contribution. 
> 
> Before submitting this PR, please make sure:
> 
> - [x] Your code builds clean without any errors or warnings
> - [x] You are not breaking consistency
> - [x] You have added unit tests
> - [x] All tests and other checks pass

---

Hi! 
long time user of fff but one thing always annoyed me:

_Why do we have to call `RESET_FAKE()` for each fake function individually? Wouldn't it be nice to have a **reset all fakes** macro?_

Personally I don't see a reason why not. So I went ahead and implemented a crude solution I thought I'd share.

This PR adds a `FFF_RESET_CALLED_FAKES()` macro which, similar to `FFF_RESET_HISTORY()` can be placed in the global _setup_ section of your unit-test. Internally we maintain a `reset_list` inside the global `fff` struct. Once a fake function is called, the respective `_reset` function pointer is placed in this list. `FFF_RESET_CALLED_FAKES` simply invokes every function inside `fff.reset_list`.

Best regards

PS: FFF is awesome!