### PR TITLE
Remove consecutive returns

### DIFF
--- a/fff.h
+++ b/fff.h
@@ -1647,14 +1647,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -1701,14 +1699,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -1758,14 +1754,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -1818,14 +1812,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -1881,14 +1873,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -1947,14 +1937,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2016,14 +2004,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2088,14 +2074,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2163,14 +2147,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2241,14 +2223,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2322,14 +2302,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2406,14 +2384,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2493,14 +2469,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2583,14 +2557,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2676,14 +2648,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2772,14 +2742,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2871,14 +2839,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -2973,14 +2939,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -3078,14 +3042,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -3186,14 +3148,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -3297,14 +3257,12 @@ FFF_END_EXTERN_C
                 RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
             } \
         } \
         if (FUNCNAME##_fake.custom_fake){  \
             RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
             SAVE_RET_HISTORY(FUNCNAME, ret); \
             return ret; \
-            return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19); \
         } \
         RETURN_FAKE_RESULT(FUNCNAME) \
     } \
@@ -4858,7 +4816,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -4924,7 +4881,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -4993,7 +4949,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -5065,7 +5020,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -5140,7 +5094,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -5218,7 +5171,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -5299,7 +5251,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -5383,7 +5334,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -5470,7 +5420,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -5560,7 +5509,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -5653,7 +5601,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -5749,7 +5696,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -5848,7 +5794,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -5950,7 +5895,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -6055,7 +5999,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -6163,7 +6106,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -6274,7 +6216,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -6388,7 +6329,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \
@@ -6505,7 +6445,6 @@ FFF_END_EXTERN_C
                 SAVE_RET_HISTORY(FUNCNAME, ret); \
                 va_end(ap); \
                 return ret; \
-                return FUNCNAME##_fake.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len-1](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, ap); \
             } \
         } \
         if(FUNCNAME##_fake.custom_fake){ \


### PR DESCRIPTION
Remove consecutive returns coming in with last change. Static code analysis tools (e.g. CPP check) will find these issues.