### PR TITLE
Supressing pedantic warnings on GCC

### DIFF
--- a/fakegen.rb
+++ b/fakegen.rb
@@ -8,6 +8,11 @@ $MAX_ARGS = 20
 $DEFAULT_ARG_HISTORY = 50
 $MAX_CALL_HISTORY = 50
 
+def output_pragmas
+  putd "#pragma GCC system_header"
+  puts
+end
+
 def include_dependencies
   putd "#include <stdarg.h>"
   putd "#include <string.h> /* For memset and memcpy */"
@@ -637,6 +642,7 @@ end
 
 def output_c_and_cpp(has_calling_conventions)
   include_guard {
+    output_pragmas
     include_dependencies
     output_constants
     output_internal_helper_macros

--- a/fff.h
+++ b/fff.h
@@ -26,6 +26,8 @@ SOFTWARE.
 #ifndef FAKE_FUNCTIONS
 #define FAKE_FUNCTIONS
 
+#pragma GCC system_header
+
 #include <stdarg.h>
 #include <string.h> /* For memset and memcpy */
 


### PR DESCRIPTION
fff.h woudn't compile under gcc 9.20 with all warnings enabled. Adding the
[pragma system_header](https://gcc.gnu.org/onlinedocs/cpp/System-Headers.html) supresses such warnings.

Thank you for your contribution. 

Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are not breaking consistency
- [ ] You have added unit tests
- [ ] All tests and other checks pass
