### PR TITLE
Per Issue #101,

### DIFF
--- a/fff.h
+++ b/fff.h
@@ -46,10 +46,12 @@ SOFTWARE.
 /* -- INTERNAL HELPER MACROS -- */
 #define SET_RETURN_SEQ(FUNCNAME, ARRAY_POINTER, ARRAY_LEN) \
     FUNCNAME##_fake.return_val_seq = ARRAY_POINTER; \
-    FUNCNAME##_fake.return_val_seq_len = ARRAY_LEN;
+    FUNCNAME##_fake.return_val_seq_len = ARRAY_LEN; \
+    FUNCNAME##_fake.return_val_seq_idx = 0;
 #define SET_CUSTOM_FAKE_SEQ(FUNCNAME, ARRAY_POINTER, ARRAY_LEN) \
     FUNCNAME##_fake.custom_fake_seq = ARRAY_POINTER; \
-    FUNCNAME##_fake.custom_fake_seq_len = ARRAY_LEN;
+    FUNCNAME##_fake.custom_fake_seq_len = ARRAY_LEN; \
+    FUNCNAME##_fake.custom_fake_seq_idx = 0;
 
 /* Defining a function to reset a fake function */
 #define RESET_FAKE(FUNCNAME) { \


### PR DESCRIPTION
reset return sequence index when setting a return sequence.

Thank you for your contribution. 

Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are not breaking consistency
- [ ] You have added unit tests
- [ ] All tests and other checks pass


I don't have CMake 3.20 to run buildandtest, but here's a suggested addition to test/src/test_cases.include. Should fail with original code and work with update.

```
TEST_F(FFFTestSuite, return_value_sequence_update)
{
    long myReturnVals[] = { 3, 7 };
    SET_RETURN_SEQ(longfunc0, myReturnVals, 2);
    ASSERT_EQ(myReturnVals[0], longfunc0());
    ASSERT_EQ(myReturnVals[1], longfunc0());
    long moreReturnVals[] = { 9, 11 };
    SET_RETURN_SEQ(longfunc0, moreReturnVals, 2);
    ASSERT_EQ(moreReturnVals[0], longfunc0());
    ASSERT_EQ(moreReturnVals[1], longfunc0());
}
```
