### PR TITLE
Make fff installable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,33 +9,39 @@ set(CMAKE_CXX_STANDARD 11)
 # Enable ctest
 enable_testing()
 
-add_library(fff INTERFACE)
-
 option(FFF_GENERATE "If enabled, fff.h will be regenerated using ruby" OFF)
 
 # Generate fff.h if fakegen.rb changed
 if(FFF_GENERATE)
+  find_package(Ruby REQUIRED)
+
   add_custom_command(
     OUTPUT
-      ${CMAKE_CURRENT_LIST_DIR}/fff.h
+      ${CMAKE_BINARY_DIR}/fff.h
     COMMAND
-      ruby ${CMAKE_CURRENT_LIST_DIR}/fakegen.rb >> ${CMAKE_CURRENT_LIST_DIR}/fff.h
+      ${Ruby_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/fakegen.rb >> ${CMAKE_BINARY_DIR}/fff.h
     DEPENDS
       ${CMAKE_CURRENT_LIST_DIR}/fakegen.rb
       ${CMAKE_CURRENT_LIST_DIR}/LICENSE
   )
-  add_custom_target(fff_h DEPENDS ${CMAKE_CURRENT_LIST_DIR}/fff.h)
+  add_library(fff INTERFACE ${CMAKE_BINARY_DIR}/fff.h)
+  target_include_directories(fff INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+  set_target_properties(fff
+    PROPERTIES PUBLIC_HEADER "${CMAKE_BINARY_DIR}/fff.h"
+  )
 else()
-  add_library(fff_h INTERFACE)
-  set_target_properties(fff_h
+  add_library(fff INTERFACE)
+  target_include_directories(fff INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+  set_target_properties(fff
     PROPERTIES PUBLIC_HEADER "fff.h"
   )
 endif()
-
-add_dependencies(fff fff_h)
-
-# Add an interface library for fff.h
-target_include_directories(fff INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
 option(FFF_UNIT_TESTING "If enabled, fff tests will be compiled and run" OFF)
 
@@ -44,3 +50,16 @@ if(FFF_UNIT_TESTING)
   add_subdirectory(test)
   add_subdirectory(examples)
 endif()
+
+include(GNUInstallDirs)
+
+install(TARGETS fff EXPORT fffTargets
+  PUBLIC_HEADER
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(EXPORT fffTargets
+  FILE fffTargets.cmake
+  NAMESPACE fff::
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake/fff)
+install(FILES fffConfig.cmake
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake/fff)

--- a/fffConfig.cmake
+++ b/fffConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/fffTargets.cmake")


### PR DESCRIPTION
This commit make fff installable, via `cmake --install <build-dir> --prefix <some-install-prefix>` for example.  During installation, imported targets are created, such that users are able to use fff like this:

```cmake
find_package(fff REQUIRED)

add_executable(some_test some_test.ccp)
target_link_libraries(some_test PRIVATE fff::fff)
```

This won't affect users who embed fff in their source trees.

Furthermore, if `FFF_GENERATE` is enable, fff.h is generated into the build folder, instead of overwriting the pre-generated fff.h.

Thank you for your contribution.

Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are not breaking consistency
- [ ] You have added unit tests (doesn't apply)
- [x] All tests and other checks pass
