### PR TITLE
Add more checks in unit tests

### DIFF
--- a/test/src/fff_test_c.c
+++ b/test/src/fff_test_c.c
@@ -107,12 +107,16 @@ int main()
     RUN_TEST(FFFTestSuite, call_history_will_not_write_past_array_bounds);
     RUN_TEST(FFFTestSuite, calling_fake_registers_one_call);
 
+    RUN_TEST(FFFTestSuite, return_value_saved_in_history);
+    RUN_TEST(FFFTestSuite, return_value_sequences_reset);
+    RUN_TEST(FFFTestSuite, return_value_sequence_saved_in_history);
     RUN_TEST(FFFTestSuite, return_value_sequences_not_exhausted);
     RUN_TEST(FFFTestSuite, return_value_sequences_exhausted);
     RUN_TEST(FFFTestSuite, default_constants_can_be_overridden);
 
     RUN_TEST(FFFTestSuite, can_register_custom_fake);
     RUN_TEST(FFFTestSuite, when_value_custom_fake_called_THEN_it_returns_custom_return_value);
+    RUN_TEST(FFFTestSuite, return_values_from_custom_fake_saved_in_history);
 
     RUN_TEST(FFFTestSuite, use_void_vararg_fake_with_different_number_of_arguments);
     RUN_TEST(FFFTestSuite, use_value_vararg_fake_with_different_number_of_arguments);

--- a/test/src/test_cases.include
+++ b/test/src/test_cases.include
@@ -68,6 +68,9 @@ TEST_F(FFFTestSuite, when_fake_func_called_then_const_arguments_captured)
 {
     char dst[80];
     strlcpy3(dst, __FUNCTION__, sizeof(__FUNCTION__));
+    ASSERT_EQ(strlcpy3_fake.arg0_val, dst);
+    ASSERT_EQ(strlcpy3_fake.arg1_val, __FUNCTION__);
+    ASSERT_EQ(strlcpy3_fake.arg2_val, sizeof(__FUNCTION__));
 }
 #endif /* __cplusplus */
 


### PR DESCRIPTION
Summary:

- Added calls to tests that were defined but not yet referenced
- Added relevant checks in test `when_fake_func_called_then_const_arguments_captured`

Checklist:
- [x] Your code builds clean without any errors or warnings
- [x] You are not breaking consistency
- [x] You have added unit tests
- [x] All tests and other checks pass
